### PR TITLE
fix: add bilibili wap api As a backup interface

### DIFF
--- a/server/sources/bilibili.ts
+++ b/server/sources/bilibili.ts
@@ -1,4 +1,4 @@
-interface Res {
+interface PCRes {
   code: number
   message: string
   ttl: number
@@ -18,13 +18,63 @@ interface Res {
   }
 }
 
-const hotSearch = defineSource(async () => {
-  const url = "https://api.bilibili.com/x/web-interface/wbi/search/square?limit=30"
+interface WapRes {
+  code: number
+  exp_str: string
+  list: {
+    hot_id: number
+    keyword: string
+    show_name: string
+    score: number
+    word_type: number
+    goto_type: number
+    goto_value: string
+    icon: string
+    live_id: any[]
+    call_reason: number
+    heat_layer: string
+    pos: number
+    id: number
+    status: string
+    name_type: string
+    resource_id: number
+    set_gray: number
+    card_values: any[]
+    heat_score: number
+    stat_datas: {
+      etime: string
+      stime: string
+      is_commercial: string
+    }
+  }[]
+  top_list: any[]
+  hotword_egg_info: string
+  seid: string
+  timestamp: number
+  total_count: number
+}
 
-  const res: Res = await $fetch(url, {
+/**
+ * 将 latin1 编码的字符串转换为 utf-8
+ */
+function decodeLatin1(str: string): string {
+  try {
+    return decodeURIComponent(escape(str))
+  } catch (e) {
+    logger.error("Failed to decode Latin1 string:", e)
+    return str
+  }
+}
+
+/**
+ * 获取哔哩哔哩热搜，PC端
+ */
+async function fetchPCApi() {
+  const url = "https://api.bilibili.com/x/web-interface/wbi/search/square?limit=15"
+
+  const res: PCRes = await $fetch(url, {
     headers: {
       "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
-      // "Cookie": "your_cookie_here"
     },
   })
 
@@ -36,6 +86,32 @@ const hotSearch = defineSource(async () => {
       icon: k.icon && `/api/proxy?img=${encodeURIComponent(k.icon)}`,
     },
   }))
+}
+
+/**
+ * 获取哔哩哔哩热搜，WAP端
+ */
+async function fetchWAPApi() {
+  const url = "https://s.search.bilibili.com/main/hotword"
+  const res: WapRes = await $fetch(url)
+
+  return res.list.map(k => ({
+    id: decodeLatin1(k.keyword),
+    title: decodeLatin1(k.show_name),
+    url: `https://search.bilibili.com/all?keyword=${encodeURIComponent(k.keyword)}`,
+    extra: {
+      icon: k.icon && `/api/proxy?img=${encodeURIComponent(k.icon)}`,
+    },
+  }))
+}
+
+const hotSearch = defineSource(async () => {
+  try {
+    return await fetchPCApi()
+  } catch (error) {
+    logger.error(error)
+    return await fetchWAPApi()
+  }
 })
 
 export default defineSource({


### PR DESCRIPTION
<img width="479" alt="image" src="https://github.com/user-attachments/assets/a4859517-bf10-4421-a9b5-cef2385ad728">

增加B 站 wap 端 API 接口，但是只有十个，作为备用。
减少 pc 端请求个数，减少错误次数
尝试修复 https://github.com/ourongxing/newsnow/issues/6