### PR TITLE
style: resolve the issue of CMDK dialog blurring caused by transform

### DIFF
--- a/src/components/common/search-bar/cmdk.css
+++ b/src/components/common/search-bar/cmdk.css
@@ -34,7 +34,8 @@
     z-index: 999;
     left: 50%;
     top: 50%;
-    transform: translateX(-50%) translateY(-50%);
+    /* transform: translateX(-50%) translateY(-50%); */
+    transform: translate(round(-50%, 1px), round(-50%, 1px));
 }
 
 [cmdk-dialog] {


### PR DESCRIPTION
Refactor transform property to enhance visual clarity

- Updated the transform property of [cmdk-dialog] from `translateX(-50%) translateY(-50%)` to `translate(round(-50%, 1px), round(-50%, 1px))`.
- This change ensures that the dialog's position is calculated using rounded pixel values, mitigating potential sub-pixel rendering issues.
- The modification aims to improve visual sharpness and compatibility across different devices and screen resolutions.
- This adjustment is particularly beneficial for UI components requiring precise alignment and high-performance animations.