### PR TITLE
feat: optimize github avatar size

### DIFF
--- a/src/components/header/menu.tsx
+++ b/src/components/header/menu.tsx
@@ -26,7 +26,7 @@ export function Menu() {
                   className="h-6 w-6 rounded-full bg-cover"
                   style={
                     {
-                      backgroundImage: `url(${userInfo.avatar})`,
+                      backgroundImage: `url(${userInfo.avatar}&s=24)`,
                     }
                   }
                 >


### PR DESCRIPTION
Github returns the origin file, which is too big to download and display on the page.

This PR adds a parameter to the avatar url to load the compressed image, makes it faster.