### PR TITLE
fix: passing the btwaf by using playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "md5": "^2.3.0",
     "ofetch": "^1.4.1",
     "overlayscrollbars": "^2.11.1",
+    "playright": "^0.0.22",
     "pnpm": "^10.5.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "md5": "^2.3.0",
     "ofetch": "^1.4.1",
     "overlayscrollbars": "^2.11.1",
-    "playright": "^0.0.22",
+    "playwright": "^1.51.1",
     "pnpm": "^10.5.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,9 @@ importers:
       overlayscrollbars:
         specifier: ^2.11.1
         version: 2.11.1
-      playright:
-        specifier: ^0.0.22
-        version: 0.0.22
+      playwright:
+        specifier: ^1.51.1
+        version: 1.51.1
       pnpm:
         specifier: ^10.5.2
         version: 10.5.2
@@ -5022,9 +5022,6 @@ packages:
   pkg-types@2.1.0:
     resolution: {integrity: sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==}
 
-  playright@0.0.22:
-    resolution: {integrity: sha512-CAnov0flTUoiXrypVkbtDmY/K0iKCrW/RGlUO9a8jIah7u7NkTteLFt3GKHkIWOAM7rp9N751MgBGg9IkhdiYw==}
-
   playwright-core@1.51.1:
     resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
     engines: {node: '>=18'}
@@ -5874,11 +5871,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
-
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
 
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
@@ -11528,11 +11520,6 @@ snapshots:
       exsolve: 1.0.1
       pathe: 2.0.3
 
-  playright@0.0.22:
-    dependencies:
-      playwright: 1.51.1
-      typescript: 4.9.5
-
   playwright-core@1.51.1: {}
 
   playwright@1.51.1:
@@ -12509,8 +12496,6 @@ snapshots:
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
-
-  typescript@4.9.5: {}
 
   typescript@5.8.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       overlayscrollbars:
         specifier: ^2.11.1
         version: 2.11.1
+      playright:
+        specifier: ^0.0.22
+        version: 0.0.22
       pnpm:
         specifier: ^10.5.2
         version: 10.5.2
@@ -3885,6 +3888,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5014,6 +5022,19 @@ packages:
   pkg-types@2.1.0:
     resolution: {integrity: sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==}
 
+  playright@0.0.22:
+    resolution: {integrity: sha512-CAnov0flTUoiXrypVkbtDmY/K0iKCrW/RGlUO9a8jIah7u7NkTteLFt3GKHkIWOAM7rp9N751MgBGg9IkhdiYw==}
+
+  playwright-core@1.51.1:
+    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.51.1:
+    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -5853,6 +5874,11 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
+
+  typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
 
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
@@ -10289,6 +10315,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -11499,6 +11528,19 @@ snapshots:
       exsolve: 1.0.1
       pathe: 2.0.3
 
+  playright@0.0.22:
+    dependencies:
+      playwright: 1.51.1
+      typescript: 4.9.5
+
+  playwright-core@1.51.1: {}
+
+  playwright@1.51.1:
+    dependencies:
+      playwright-core: 1.51.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pluralize@8.0.0: {}
 
   pnpm-patch-i@0.4.1:
@@ -12467,6 +12509,8 @@ snapshots:
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
+
+  typescript@4.9.5: {}
 
   typescript@5.8.2: {}
 

--- a/server/utils/playwrightUtil.ts
+++ b/server/utils/playwrightUtil.ts
@@ -1,0 +1,18 @@
+import type { Browser, Page } from "playwright"
+import { chromium } from "playwright"
+
+export async function fetchHtmlContent(url: string): Promise<string> {
+  let browser: Browser | null = null
+  try {
+    browser = await chromium.launch({ headless: true })
+    const page: Page = await browser.newPage()
+    await page.goto(url, { waitUntil: "domcontentloaded" })
+    await page.waitForLoadState("networkidle")
+    const htmlContent = await page.content()
+    return htmlContent
+  } finally {
+    if (browser) {
+      await browser.close()
+    }
+  }
+}


### PR DESCRIPTION
ghxi.com被btwaf防火墙防护，故选择使用playright绕过
https://github.com/microsoft/playwright 是微软开源的在nodejs上模拟浏览器行为的工具，此工具可以解决非常多的无法访问的场景（如btwaf，验证码等），故将此也做为一个util放入server/utils/playwrightUtil.ts
此方式速度上会比fetch慢
但是由于其完全模拟浏览器的行为，所以也极难被识别