### PR TITLE
feat: add RSS and Atom feed generation utilities; implement cache TTL…

### DIFF
--- a/server/api/s/index.ts
+++ b/server/api/s/index.ts
@@ -1,9 +1,16 @@
+import { createError, defineEventHandler, getQuery, setResponseHeader } from "h3"
 import type { SourceID, SourceResponse } from "@shared/types"
+import { sources } from "@shared/sources"
+import { TTL } from "#/consts"
 import { getters } from "#/getters"
 import { getCacheTable } from "#/database/cache"
 import type { CacheInfo } from "#/types"
+import { jsonToAtom, jsonToRSS } from "#/utils/feed"
+import { logger } from "#/utils/logger"
 
-export default defineEventHandler(async (event): Promise<SourceResponse> => {
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const format = query.format || "json"
   try {
     const query = getQuery(event)
     const latest = query.latest !== undefined && query.latest !== "false"
@@ -23,10 +30,26 @@ export default defineEventHandler(async (event): Promise<SourceResponse> => {
     if (cacheTable) {
       cache = await cacheTable.get(id)
       if (cache) {
-      // if (cache) {
         // interval 刷新间隔，对于缓存失效也要执行的。本质上表示本来内容更新就很慢，这个间隔内可能内容压根不会更新。
         // 默认 10 分钟，是低于 TTL 的，但部分 Source 的更新间隔会超过 TTL，甚至有的一天更新一次。
         if (now - cache.updated < sources[id].interval) {
+          if (format === "rss") {
+            setResponseHeader(event, "Content-Type", "application/rss+xml; charset=utf-8")
+            return jsonToRSS({
+              status: "success",
+              id,
+              updatedTime: now,
+              items: cache.items,
+            })
+          } else if (format === "atom") {
+            setResponseHeader(event, "Content-Type", "application/atom+xml; charset=utf-8")
+            return jsonToAtom({
+              status: "success",
+              id,
+              updatedTime: now,
+              items: cache.items,
+            })
+          }
           return {
             status: "success",
             id,
@@ -44,6 +67,23 @@ export default defineEventHandler(async (event): Promise<SourceResponse> => {
           // 没有 latest
           // 有 latest，服务器可以登录但没有登录
           if (!latest || (!event.context.disabledLogin && !event.context.user)) {
+            if (format === "rss") {
+              setResponseHeader(event, "Content-Type", "application/rss+xml; charset=utf-8")
+              return jsonToRSS({
+                status: "cache",
+                id,
+                updatedTime: cache.updated,
+                items: cache.items,
+              })
+            } else if (format === "atom") {
+              setResponseHeader(event, "Content-Type", "application/atom+xml; charset=utf-8")
+              return jsonToAtom({
+                status: "cache",
+                id,
+                updatedTime: cache.updated,
+                items: cache.items,
+              })
+            }
             return {
               status: "cache",
               id,
@@ -62,14 +102,40 @@ export default defineEventHandler(async (event): Promise<SourceResponse> => {
         else await cacheTable.set(id, newData)
       }
       logger.success(`fetch ${id} latest`)
-      return {
+      const response: SourceResponse = {
         status: "success",
         id,
         updatedTime: now,
         items: newData,
       }
+
+      if (format === "rss") {
+        setResponseHeader(event, "Content-Type", "application/rss+xml; charset=utf-8")
+        return jsonToRSS(response)
+      } else if (format === "atom") {
+        setResponseHeader(event, "Content-Type", "application/atom+xml; charset=utf-8")
+        return jsonToAtom(response)
+      }
+      return response
     } catch (e) {
       if (cache!) {
+        if (format === "rss") {
+          setResponseHeader(event, "Content-Type", "application/rss+xml; charset=utf-8")
+          return jsonToRSS({
+            status: "cache",
+            id,
+            updatedTime: cache.updated,
+            items: cache.items,
+          })
+        } else if (format === "atom") {
+          setResponseHeader(event, "Content-Type", "application/atom+xml; charset=utf-8")
+          return jsonToAtom({
+            status: "cache",
+            id,
+            updatedTime: cache.updated,
+            items: cache.items,
+          })
+        }
         return {
           status: "cache",
           id,

--- a/server/consts.ts
+++ b/server/consts.ts
@@ -1,0 +1,5 @@
+// @ts-check
+/**
+ * Cache TTL in milliseconds (10 minutes)
+ */
+export const TTL = 1000 * 60 * 10

--- a/server/utils/feed.ts
+++ b/server/utils/feed.ts
@@ -1,0 +1,61 @@
+import type { SourceResponse } from "@shared/types"
+
+export function jsonToRSS(response: SourceResponse): string {
+  const { id, items, updatedTime } = response
+  const date = new Date(updatedTime).toUTCString()
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>${id} News</title>
+    <link>https://newsnow.com/${id}</link>
+    <description>Latest news from ${id}</description>
+    <lastBuildDate>${date}</lastBuildDate>
+    <pubDate>${date}</pubDate>
+    ${items.map(item => `
+    <item>
+      <title>${escapeXml(item.title)}</title>
+      <link>${escapeXml(item.url)}</link>
+      <description>${escapeXml(item.extra?.info || "")}</description>
+      <pubDate>${new Date(item.extra?.date || updatedTime).toUTCString()}</pubDate>
+      <guid>${escapeXml(item.id.toString())}</guid>
+    </item>
+    `).join("")}
+  </channel>
+</rss>`
+}
+
+export function jsonToAtom(response: SourceResponse): string {
+  const { id, items, updatedTime } = response
+  const date = new Date(updatedTime).toISOString()
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>${id} News</title>
+  <link href="https://newsnow.com/${id}"/>
+  <updated>${date}</updated>
+  <id>urn:uuid:${id}</id>
+  ${items.map(item => `
+  <entry>
+    <title>${escapeXml(item.title)}</title>
+    <link href="${escapeXml(item.url)}"/>
+    <summary>${escapeXml(item.extra?.info || "")}</summary>
+    <updated>${new Date(item.extra?.date || updatedTime).toISOString()}</updated>
+    <id>${escapeXml(item.id.toString())}</id>
+  </entry>
+  `).join("")}
+</feed>`
+}
+
+function escapeXml(unsafe: string): string {
+  return unsafe.replace(/[<>&'"]/g, (c) => {
+    switch (c) {
+      case "<": return "<"
+      case ">": return ">"
+      case "&": return "&"
+      case "'": return `'`
+      case "\"": return "\""
+      default: return c
+    }
+  })
+}


### PR DESCRIPTION

- **订阅接口增加输出rss和atom支持**:
   - 路径: `/api/s`
   - 参数:
     - `id`: 数据源ID(如"zhihu")
     - `latest`: 是否强制获取最新内容(true/false)
     - `format`: 返回格式(json/rss/atom)，默认为json
   - 返回格式:
     - JSON: application/json
     - RSS: application/rss+xml
     - Atom: application/atom+xml
   - 示例:
     ```
     GET /api/s?id=zhihu&format=rss
     ```
     ```
     GET /api/s?id=weibo&format=atom
     ```
     ```ts
     interface SourceResponse {
       status: "success" | "cache"
       id: string
       updatedTime: number
       items: NewsItem[]
     }
     ```