### PR TITLE
fix: Using the hupu official API

### DIFF
--- a/server/sources/hupu.ts
+++ b/server/sources/hupu.ts
@@ -1,20 +1,37 @@
-interface Res {
-  data: {
-    title: string
-    hot: string
-    url: string
-    mobil_url: string
-  }[]
+interface HotItem {
+  id: string
+  title: string
+  url: string
+  mobileUrl: string
 }
 
 export default defineSource(async () => {
-  const r: Res = await myFetch(`https://api.vvhan.com/api/hotlist/huPu`)
-  return r.data.map((k) => {
-    return {
-      id: k.url,
-      title: k.title,
-      url: k.url,
-      mobileUrl: k.mobil_url,
-    }
-  })
+  // 获取虎扑新热榜页面的HTML内容
+  const html = await myFetch(`https://bbs.hupu.com/topic-daily-hot`)
+
+  // 正则表达式匹配新的热榜项结构
+  const regex = /<li class="bbs-sl-web-post-body">[\s\S]*?<a href="(\/[^"]+?\.html)"[^>]*?class="p-title"[^>]*>([^<]+)<\/a>/g
+
+  const result: HotItem[] = []
+  let match
+
+  // 将赋值操作移到循环内部，修复no-cond-assign警告
+  while (true) {
+    match = regex.exec(html)
+    if (!match) break
+
+    const [, path, title] = match
+
+    // 构建完整URL
+    const url = `https://bbs.hupu.com${path}`
+
+    result.push({
+      id: path,
+      title: title.trim(),
+      url,
+      mobileUrl: url,
+    })
+  }
+
+  return result
 })


### PR DESCRIPTION
1. It was found that the API originally used by Hupu often fails (returns a 500 - series error and cannot be fetched).
2. Currently, Hupu does not use the official website or API for acquisition. In fact, it uses a third - party API, and its availability depends on api.vvhan.com.
3. This MR change directly fetches and parses the list through the official Hupu web - end. After testing, it behaves the same as the original list.