### PR TITLE
feat: Support generate unique news id

### DIFF
--- a/server/sources/_36kr.ts
+++ b/server/sources/_36kr.ts
@@ -1,6 +1,7 @@
 import type { NewsItem } from "@shared/types"
 import { load } from "cheerio"
 import dayjs from "dayjs/esm"
+import { generateUrlHashId } from "#/utils/source.ts"
 
 const quick = defineSource(async () => {
   const baseURL = "https://www.36kr.com"
@@ -39,7 +40,7 @@ const renqi = defineSource(async () => {
     headers: {
       "User-Agent":
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
-      "Referer": "https://www.freebuf.com/",
+      "Referer": "https://36kr.com",
       "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
     },
   })
@@ -50,7 +51,8 @@ const renqi = defineSource(async () => {
   // 单条新闻选择器
   const $items = $(".article-item-info")
 
-  $items.each((_, el) => {
+  // 使用 for...of 循环替代 .each()，以便支持 await
+  for (const el of $items) {
     const $el = $(el)
 
     // 标题和链接
@@ -67,18 +69,23 @@ const renqi = defineSource(async () => {
     const hot = $el.find(".kr-flow-bar-hot span").text().trim()
 
     if (href && title) {
+      // 构建完整URL
+      const fullUrl = href.startsWith("http") ? href : `${baseURL}${href}`
+
+      // 核心修改：调用异步函数生成哈希ID
+      const hashId = await generateUrlHashId(fullUrl)
+
       articles.push({
-        url: href.startsWith("http") ? href : `${baseURL}${href}`,
+        id: hashId, // 使用生成的哈希ID
         title,
-        id: href.slice(3), // 简化处理
-        // url.slice(url.lastIndexOf("/") + 1)
+        url: fullUrl,
         extra: {
           info: `${author}  |  ${hot}`,
           hover: description,
         },
       })
     }
-  })
+  }
   return articles
 })
 

--- a/server/sources/baidu.ts
+++ b/server/sources/baidu.ts
@@ -1,3 +1,5 @@
+import { generateUrlHashId } from "#/utils/source.ts"
+
 interface Res {
   data: {
     cards: {
@@ -16,14 +18,22 @@ export default defineSource(async () => {
   const jsonStr = (rawData as string).match(/<!--s-data:(.*?)-->/s)
   const data: Res = JSON.parse(jsonStr![1])
 
-  return data.data.cards[0].content.filter(k => !k.isTop).map((k) => {
-    return {
-      id: k.rawUrl,
-      title: k.word,
-      url: k.rawUrl,
-      extra: {
-        hover: k.desc,
-      },
-    }
-  })
+  // 使用 Promise.all并行化处理提升generateUrlHashId函数的哈希性能
+  return await Promise.all(
+    data.data.cards[0].content
+      .filter(k => !k.isTop)
+      .map(async (k) => {
+        // 使用 generateUrlHashId 生成news id
+        const hashId = await generateUrlHashId(k.rawUrl)
+
+        return {
+          id: hashId, // 使用生成的哈希作为唯一ID
+          title: k.word,
+          url: k.rawUrl,
+          extra: {
+            hover: k.desc,
+          },
+        }
+      }),
+  )
 })

--- a/server/sources/douban.ts
+++ b/server/sources/douban.ts
@@ -1,3 +1,5 @@
+import { generateUrlHashId } from "#/utils/source.ts"
+
 interface HotMoviesRes {
   category: string
   tags: []
@@ -35,13 +37,18 @@ export default defineSource(async () => {
       Accept: "application/json, text/plain, */*",
     },
   })
-  return res.items.map(movie => ({
-    id: movie.id,
-    title: movie.title,
-    url: `https://movie.douban.com/subject/${movie.id}`,
-    extra: {
-      info: movie.card_subtitle.split(" / ").slice(0, 3).join(" / "),
-      hover: movie.card_subtitle,
-    },
+  return await Promise.all(res.items.map(async (movie) => {
+    const fullUrl = `https://movie.douban.com/subject/${movie.id}`
+
+    const hashId = await generateUrlHashId(fullUrl)
+    return {
+      id: hashId,
+      title: movie.title,
+      url: fullUrl,
+      extra: {
+        info: movie.card_subtitle.split(" / ").slice(0, 3).join(" / "),
+        hover: movie.card_subtitle,
+      },
+    }
   }))
 })

--- a/server/sources/tencent.ts
+++ b/server/sources/tencent.ts
@@ -1,5 +1,5 @@
 import { myFetch } from "#/utils/fetch"
-import { defineSource } from "#/utils/source"
+import { defineSource, generateUrlHashId } from "#/utils/source"
 
 interface WapRes {
   ret: number
@@ -48,14 +48,20 @@ const comprehensiveNews = defineSource(async () => {
       Referer: "https://news.qq.com/",
     },
   })
-  return res.data.tabs[0].articleList.map(news => ({
-    id: news.id,
-    title: news.title,
-    url: news.link_info.url,
-    extra: {
-      hover: news.desc,
-    },
-  }))
+  return await Promise.all(
+    res?.data?.tabs?.[0]?.articleList.map(async (news) => {
+      // 构建完整URL
+      const fullUrl = news.link_info.url
+
+      const hashId = await generateUrlHashId(fullUrl)
+      return {
+        id: hashId,
+        title: news.title,
+        url: news.link_info.url,
+        extra: { hover: news.desc },
+      }
+    }),
+  )
 })
 
 export default defineSource({

--- a/server/sources/weibo.ts
+++ b/server/sources/weibo.ts
@@ -1,4 +1,5 @@
 import * as cheerio from "cheerio"
+import { generateUrlHashId } from "#/utils/source.ts"
 
 export default defineSource(async () => {
   const baseurl = "https://s.weibo.com"
@@ -19,7 +20,7 @@ export default defineSource(async () => {
 
   const hotNews: NewsItem[] = []
 
-  rows.each((_, row) => {
+  for (const row of rows) {
     const $row = $(row)
     const $link = $row.find("td.td-02 a").filter((_, el) => {
       const href = $(el).attr("href")
@@ -36,17 +37,21 @@ export default defineSource(async () => {
           新: "https://simg.s.weibo.com/moter/flags/1_0.png",
           热: "https://simg.s.weibo.com/moter/flags/2_0.png",
         }[$flag]
+
+        const fullUrl = href.startsWith("http") ? href : `${baseurl}${href}`
+        const hashId = await generateUrlHashId(fullUrl)
+
         hotNews.push({
-          id: title,
+          id: hashId,
           title,
-          url: `${baseurl}${href}`,
-          mobileUrl: `${baseurl}${href}`,
+          url: fullUrl,
+          mobileUrl: fullUrl,
           extra: {
             icon: flagUrl ? { url: proxyPicture(flagUrl), scale: 1.5 } : undefined,
           },
         })
       }
     }
-  })
+  }
   return hotNews
 })

--- a/server/utils/source.ts
+++ b/server/utils/source.ts
@@ -54,3 +54,63 @@ export function proxySource(proxyUrl: string, source: SourceGetter) {
       })
     : source
 }
+
+/**
+ * 根据URL的生成固定长度哈希ID
+ * @param url - 原始URL字符串
+ * @param options - 配置选项
+ * @param options.length - 返回的ID长度（默认32）
+ * @returns 固定长度的哈希字符串
+ */
+export async function generateUrlHashId(url: string, options: { length?: number } = {}): Promise<string> {
+  const { length = 32 } = options
+
+  // 1. 规范化URL（关键步骤，确保相同页面的不同URL变体能生成相同ID）
+  const normalizedUrl = normalizeUrl(url)
+
+  // 2. 根据"SHA-256"算法调用你的加密函数
+  const fullHash: string = await myCrypto(normalizedUrl, "SHA-256")
+
+  // 3. 截取指定长度
+  // 注意：MD5固定32位，SHA-1固定40位，SHA-256固定64位，截取不会影响唯一性
+  return fullHash.substring(0, length)
+}
+
+/**
+ * URL规范化函数（根据你的业务需求调整）
+ * 目的是将同一网页的不同URL形式统一，确保生成相同的哈希ID
+ */
+function normalizeUrl(url: string): string {
+  try {
+    const urlObj = new URL(url)
+
+    // 统一协议和主机名大小写
+    urlObj.protocol = urlObj.protocol.toLowerCase()
+    urlObj.hostname = urlObj.hostname.toLowerCase()
+
+    // 移除URL末尾的斜杠（可选，根据你的需求）
+    urlObj.pathname = urlObj.pathname.replace(/\/$/, "")
+
+    // 对查询参数按名称排序（使?a=1&b=2和?b=2&a=1产生相同结果）
+    urlObj.searchParams.sort()
+
+    // 移除特定的跟踪参数（如UTM参数，这些不影响页面内容）
+    const paramsToRemove = [
+      "utm_source",
+      "utm_medium",
+      "utm_campaign",
+      "utm_term",
+      "utm_content",
+      "fbclid",
+      "gclid",
+    ]
+    paramsToRemove.forEach(param => urlObj.searchParams.delete(param))
+
+    // 返回规范化后的完整URL
+    return urlObj.toString()
+  } catch (error) {
+    // 如果URL不合法（如相对URL或格式错误），返回原始字符串或进行其他处理
+    console.warn(`URL规范化失败，使用原始URL: ${url}`, error)
+    return url
+  }
+}


### PR DESCRIPTION
我在做提取新闻关键字时候，发现每条新闻的id都千奇百怪，有的是url、有的是随机数字，甚至有的还是证券代码。

当将所有新闻提取到数据库持久化以后，对根据新闻关键字溯源，根据新闻id查找新闻一点也不友好，也不利于对新闻进行数据分析做拓展。

基于我个人的需求，以及为以后项目的拓展做准备，所以我定义并实现了一个生成统一格式的新闻id的函数，这个函数基于新闻的url，做sha256的哈希，然后默认是取32位的长度，由于每条新闻的url是唯一的，所以生成的id也是唯一的，至少在百亿级别条新闻上能保证新闻id唯一。

统一格式和长度的新闻id在数据库或者es中也好做索引和检索，当然也不强制其他人去重构这个新闻id的问题，这个生成id的函数侵入性很小，使用方式也很简单，函数的注释也很详细，当大家发现没有新闻id可以使用的时候，这会是一个很好的备选方案。我也重构了几个数据源的id作为示例，大家可以参考选择性使用。