### PR TITLE
fix(rss): handle array-type link fields in rss2json parser

### DIFF
--- a/server/utils/rss2json.test.ts
+++ b/server/utils/rss2json.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest"
+import { rss2json } from "./rss2json"
+import { myFetch } from "./fetch"
+
+// Mock myFetch
+vi.mock("./fetch", () => ({
+  myFetch: vi.fn(),
+}))
+
+describe("rss2json", () => {
+  it("should handle Atom feed with multiple links", async () => {
+    const atomXml = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Feed</title>
+  <link href="http://example.org/feed/" rel="self" />
+  <link href="http://example.org/" />
+  <updated>2003-12-13T18:30:02Z</updated>
+  <author>
+    <name>John Doe</name>
+  </author>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <entry>
+    <title>Atom-Powered Robots Run Amok</title>
+    <link href="http://example.org/2003/12/13/atom03" />
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <summary>Some text.</summary>
+  </entry>
+</feed>`
+
+    vi.mocked(myFetch).mockResolvedValue(atomXml)
+
+    const result = await rss2json("http://example.org/feed")
+    expect(result).toBeDefined()
+    // This expects a string
+    expect(typeof result?.link).toBe("string")
+    expect(result?.link).toBe("http://example.org/")
+
+    // Check item link
+    expect(result?.items.length).toBe(1)
+    expect(typeof result?.items[0].link).toBe("string")
+    expect(result?.items[0].link).toBe("http://example.org/2003/12/13/atom03")
+  })
+
+  it("should prioritize alternate link or no-rel link", async () => {
+      const atomXml = `<?xml version="1.0" encoding="utf-8"?>
+  <feed xmlns="http://www.w3.org/2005/Atom">
+    <title>Test Feed</title>
+    <link href="http://example.org/feed/" rel="self" />
+    <link href="http://example.org/alternate" rel="alternate" />
+    <updated>2003-12-13T18:30:02Z</updated>
+    <entry>
+      <title>Test</title>
+      <link href="http://example.org/entry/self" rel="self" />
+      <link href="http://example.org/entry/alternate" rel="alternate" />
+      <updated>2003-12-13T18:30:02Z</updated>
+    </entry>
+  </feed>`
+
+      vi.mocked(myFetch).mockResolvedValue(atomXml)
+
+      const result = await rss2json("http://example.org/feed")
+      expect(result).toBeDefined()
+      expect(result?.link).toBe("http://example.org/alternate")
+      expect(result?.items[0].link).toBe("http://example.org/entry/alternate")
+    })
+})

--- a/server/utils/rss2json.ts
+++ b/server/utils/rss2json.ts
@@ -1,6 +1,16 @@
 import { XMLParser } from "fast-xml-parser"
 import type { RSSInfo } from "../types"
 
+function getLink(link: any): string {
+  if (!link) return ""
+  if (typeof link === "string") return link
+  if (Array.isArray(link)) {
+    const alternate = link.find((l: any) => l.rel === "alternate" || !l.rel)
+    return alternate?.href ?? link[0]?.href ?? ""
+  }
+  return link.href ?? ""
+}
+
 export async function rss2json(url: string): Promise<RSSInfo | undefined> {
   if (!/^https?:\/\/[^\s$.?#].\S*/i.test(url)) return
 
@@ -20,7 +30,7 @@ export async function rss2json(url: string): Promise<RSSInfo | undefined> {
   const rss = {
     title: channel.title ?? "",
     description: channel.description ?? "",
-    link: channel.link && channel.link.href ? channel.link.href : channel.link,
+    link: getLink(channel.link),
     image: channel.image ? channel.image.url : channel["itunes:image"] ? channel["itunes:image"].href : "",
     category: channel.category || [],
     updatedTime: channel.lastBuildDate ?? channel.updated,
@@ -38,7 +48,7 @@ export async function rss2json(url: string): Promise<RSSInfo | undefined> {
       id: val.guid && val.guid.$text ? val.guid.$text : val.id,
       title: val.title && val.title.$text ? val.title.$text : val.title,
       description: val.summary && val.summary.$text ? val.summary.$text : val.description,
-      link: val.link && val.link.href ? val.link.href : val.link,
+      link: getLink(val.link),
       author: val.author && val.author.name ? val.author.name : val["dc:creator"],
       created: val.updated ?? val.pubDate ?? val.created,
       category: val.category || [],


### PR DESCRIPTION
- Add `getLink` helper to extract a single URL string from `link` fields that may be strings, objects, or arrays (common in Atom feeds).
- Prioritize `rel="alternate"` or links without `rel` attributes.
- Update `rss2json` to use this helper for both channel/feed links and item/entry links.
- Add unit tests in `server/utils/rss2json.test.ts`.