### PR TITLE
Make /api/s resilient to source fetch failures (return empty list when no cache)

### DIFF
--- a/server/api/s/index.ts
+++ b/server/api/s/index.ts
@@ -77,7 +77,16 @@ export default defineEventHandler(async (event): Promise<SourceResponse> => {
           items: cache.items,
         }
       } else {
-        throw e
+        // 单个 source 抓取失败时（例如目标站点封禁/405/超时）不要让整个接口 500，
+        // 以免 MCP/Agent 调用直接崩溃。返回空列表并记录日志。
+        logger.error(e)
+        return {
+          status: "success",
+          id,
+          updatedTime: now,
+          items: [],
+        }
+      }
       }
     }
   } catch (e: any) {


### PR DESCRIPTION
## 背景 / Background

中文：部分源（例如 FreeBuf）在当前环境会对抓取请求返回 405 Not Allowed，导致返回值直接变成 500。在 MCP/Agent 场景里，单个源 500 会让工具调用失败，进而中断整次 agent 执行。

English: Some sources (e.g., FreeBuf) respond with 405 Not Allowed in our environment, which makes return 500. In MCP/Agent flows, a single source returning 500 can fail the tool call and break the entire agent run.

## 改动 / Change

中文：更新 [index.ts]：当拉取 [getters[id]()]id 失败时
有缓存：保持原逻辑，返回缓存（status: "cache"）。
无缓存：不再抛出错误导致 500；记录错误日志并返回一个合法的 [SourceResponse]，其中 [items: []]（status: "success"）。

English: Updated [index.ts]. When [getters[id]()]id fails:
If cache exists: keep existing behavior and return cached data ([status: "cache"].
If no cache: do not throw and produce a 500; log the error and return a valid [SourceResponse] with [items: []]([status: "success"].

## 收益 / Benefits

中文：单个源异常不再拖垮 /api/s，上层 MCP/Agent 调用更稳，返回结构保持一致。

English: A single broken source no longer brings down /api/s; MCP/Agent calls become more reliable and the response shape stays consistent.

## 验证 / Verification

中文：curl http://localhost:4444/api/s?id=freebuf
预期：返回 200，body 中 [items]为空数组（而不是 500）。

English: curl http://localhost:4444/api/s?id=freebuf
Expected: returns 200 with [items: []] (instead of 500).