### PR TITLE
fix(source): update fastbull express selectors for new page structure

### DIFF
--- a/server/sources/fastbull.ts
+++ b/server/sources/fastbull.ts
@@ -8,11 +8,10 @@ const express = defineSource(async () => {
   const $main = $(".news-list")
   const news: NewsItem[] = []
   $main.each((_, el) => {
-    const a = $(el).find(".title_name")
-    const url = a.attr("href")
-    const titleText = a.text()
+    const titleText = $(el).find(".title_name").text()
     const title = titleText.match(/【(.+)】/)?.[1] ?? titleText
-    const date = $(el).attr("data-date")
+    const url = $(el).find("[data-href]").attr("data-href")
+    const date = $(el).attr("data-date") || $(el).find("[data-time]").attr("data-time")
     if (url && title && date) {
       news.push({
         url: baseURL + url,


### PR DESCRIPTION
## Summary

- fastbull 改版页面结构，`.title_name` 从 `<a>` 变为 `<span>`，不再有 `href`
- 链接移到了 `[data-href]` 属性上，日期从 `data-date` 改为 `[data-time]`
- 更新选择器适配新结构，已验证可正常获取 30 条快讯数据

Closes #334

## Test plan

- [x] `pnpm dev` 启动后访问"实时"tab，确认法布财经快讯正常展示
- [x] 确认每条新闻有标题、链接和时间