### PR TITLE
Change GitHub links in menu component

### DIFF
--- a/src/components/header/menu.tsx
+++ b/src/components/header/menu.tsx
@@ -71,7 +71,7 @@ export function Menu() {
               </li>
               <li className="flex gap-2 items-center">
                 <a
-                  href="https://github.com/ourongxing/newsnow"
+                  href="https://github.com"
                 >
                   <img
                     alt="GitHub stars badge"
@@ -79,7 +79,7 @@ export function Menu() {
                   />
                 </a>
                 <a
-                  href="https://github.com/ourongxing/newsnow/fork"
+                  href="https://github.com"
                 >
                   <img
                     alt="GitHub forks badge"


### PR DESCRIPTION
Updated GitHub links in the menu component to point to the main GitHub page.